### PR TITLE
Spotify Player: Error Handle + Refresh Token

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -42,6 +42,6 @@ export async function POST(request: NextRequest) {
     return res;
   } catch (err) {
     console.error('Token refresh failed:', err);
-    return NextResponse.json({ error: 'Refresh failed' }, { status: 401 });
+    return NextResponse.json({ error: 'Refresh failed' }, { status: 502 });
   }
 }

--- a/src/features/auth/hooks/useAuthApi.ts
+++ b/src/features/auth/hooks/useAuthApi.ts
@@ -1,0 +1,34 @@
+"use client";
+
+export const useAuthApi = () => {
+  const getToken = async (): Promise<string> => {
+    const res = await fetch('/api/auth/token', { credentials: 'include' });
+    const contentType = res.headers.get?.('content-type') || '';
+    if (contentType.includes('text/html')) {
+      throw new Error('unauthorized');
+    }
+
+    if (!res.ok) {
+      if (res.status === 401) throw new Error('unauthorized');
+      if (res.status === 502) throw new Error('gateway');
+      const json = await res.json().catch(() => ({}));
+      throw new Error(json.error || `HTTP ${res.status}`);
+    }
+
+    const data = await res.json().catch(() => ({}));
+    return data.token as string;
+  };
+
+  const refresh = async (): Promise<void> => {
+    const res = await fetch('/api/auth/refresh', { method: 'POST', credentials: 'include' });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      if (res.status === 502) throw new Error('gateway');
+      throw new Error(json.error || `HTTP ${res.status}`);
+    }
+  };
+
+  return { getToken, refresh } as const;
+};
+
+export default useAuthApi;

--- a/src/features/auth/services/spotifyAuthService.ts
+++ b/src/features/auth/services/spotifyAuthService.ts
@@ -8,6 +8,33 @@ export type TokenResponse = {
   refresh_token?: string;
 };
 
+// Retry policy defaults (Option A)
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 500; // 500ms
+const MAX_DELAY_MS = 8000; // cap delay to 8s
+const JITTER_FACTOR = 0.5; // ±50%
+
+function sleep(ms: number) {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const trimmed = header.trim();
+  // If it's a number (seconds)
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = parseInt(trimmed, 10);
+    return Number.isFinite(seconds) ? seconds : null;
+  }
+  // Otherwise try HTTP-date
+  const date = new Date(trimmed);
+  if (!isNaN(date.getTime())) {
+    const diff = Math.ceil((date.getTime() - Date.now()) / 1000);
+    return diff > 0 ? diff : 0;
+  }
+  return null;
+}
+
 async function postTokenForm(params: URLSearchParams): Promise<TokenResponse> {
   if (!process.env.SPOTIFY_CLIENT_ID || !process.env.SPOTIFY_CLIENT_SECRET) {
     throw new Error('Missing Spotify client credentials');
@@ -15,28 +42,86 @@ async function postTokenForm(params: URLSearchParams): Promise<TokenResponse> {
 
   const authHeader = `Basic ${Buffer.from(`${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`).toString('base64')}`;
 
-  const resp = await fetch(SPOTIFY_TOKEN_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Authorization: authHeader,
-    },
-    body: params.toString(),
-  });
+  let lastError: any = null;
 
-  const text = await resp.text();
-  let data: any = {};
-  try {
-    data = JSON.parse(text);
-  } catch (e) {
-    // if parse fails, keep data as empty object
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const resp = await fetch(SPOTIFY_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: authHeader,
+        },
+        body: params.toString(),
+      });
+
+      const text = await resp.text().catch(() => '');
+      let data: any = {};
+      try {
+        data = text ? JSON.parse(text) : {};
+      } catch (e) {
+        data = {};
+      }
+
+      if (resp.ok) {
+        return data as TokenResponse;
+      }
+
+      // If response indicates transient condition, maybe retry
+      const status = resp.status;
+      const retryAfterHeader = resp.headers?.get?.('retry-after') ?? null;
+
+      const retriable = status === 429 || (status >= 500 && status < 600);
+
+      // If not retriable, throw immediately with body snippet
+      if (!retriable) {
+        const snippet = (typeof text === 'string' ? text : JSON.stringify(data || {})).slice(0, 200);
+        throw new Error(data.error_description || data.error || `Token request failed: ${status} ${snippet}`);
+      }
+
+      // Decide delay: honor Retry-After when present (cap it), otherwise exponential backoff
+      let delayMs: number;
+      const retryAfterSeconds = parseRetryAfter(retryAfterHeader);
+      if (retryAfterSeconds !== null) {
+        delayMs = Math.min(retryAfterSeconds * 1000, MAX_DELAY_MS);
+      } else {
+        delayMs = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS);
+      }
+
+      // Apply jitter ±JITTER_FACTOR
+      const jitterMultiplier = 1 + ((Math.random() * 2 - 1) * JITTER_FACTOR);
+      const finalDelay = Math.max(0, Math.round(delayMs * jitterMultiplier));
+
+      console.warn(`Spotify token request attempt ${attempt} failed (status ${status}). Retrying in ${finalDelay}ms. Retry-After: ${retryAfterHeader ?? 'none'}`);
+
+      // If this was the last attempt, break and throw below
+      if (attempt === MAX_ATTEMPTS) {
+        const snippet = (typeof text === 'string' ? text : JSON.stringify(data || {})).slice(0, 200);
+        lastError = new Error(data.error_description || data.error || `Token request failed after ${MAX_ATTEMPTS} attempts: ${status} ${snippet}`);
+        break;
+      }
+
+      // wait then retry
+      await sleep(finalDelay);
+      continue;
+    } catch (err: any) {
+      // Network or parsing error — consider retriable
+      lastError = err;
+      const isNetwork = true; // treat as retriable
+      if (attempt === MAX_ATTEMPTS) break;
+      // exponential backoff with jitter for network errors
+      const delayMs = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS);
+      const jitterMultiplier = 1 + ((Math.random() * 2 - 1) * JITTER_FACTOR);
+      const finalDelay = Math.max(0, Math.round(delayMs * jitterMultiplier));
+      console.warn(`Spotify token request network error attempt ${attempt}, retrying in ${finalDelay}ms: ${err?.message ?? err}`);
+      await sleep(finalDelay);
+      continue;
+    }
   }
 
-  if (!resp.ok) {
-    throw new Error(data.error_description || data.error || `Token request failed: ${resp.status}`);
-  }
-
-  return data as TokenResponse;
+  // If we reach here, all attempts exhausted
+  console.warn('Spotify token request exhausted attempts', lastError);
+  throw lastError || new Error('Token request failed after retries');
 }
 
 async function exchangeCodeForTokens(code: string, redirectUri: string): Promise<TokenResponse> {

--- a/src/features/lyrics/hooks/useSongLyrics.tsx
+++ b/src/features/lyrics/hooks/useSongLyrics.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { LyricsResult } from '@/modules/lyrics/types/lyrics';
+import { LyricsResult } from '@/features/lyrics/types/lyrics';
 
 export function useSongLyrics(artist: string, song: string, album: string, duration: number) {
   const [data, setData] = useState<LyricsResult | null>(null);

--- a/src/features/player/components/PlayerErrorBoundary.tsx
+++ b/src/features/player/components/PlayerErrorBoundary.tsx
@@ -3,10 +3,13 @@ import React from 'react';
 
 type State = { hasError: boolean };
 
-export default class PlayerErrorBoundary extends React.Component<{
+type Props = {
   children: React.ReactNode;
-}, State> {
-  constructor(props: any) {
+  onRetry?: () => void;
+};
+
+export default class PlayerErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
     super(props);
     this.state = { hasError: false };
   }
@@ -22,6 +25,7 @@ export default class PlayerErrorBoundary extends React.Component<{
 
   reset = () => {
     this.setState({ hasError: false });
+    this.props.onRetry?.();
   };
 
   render() {

--- a/src/features/player/components/SpotifyWebPlayer.tsx
+++ b/src/features/player/components/SpotifyWebPlayer.tsx
@@ -1,122 +1,40 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import { useSpotifyPlayer } from '@/features/player/context/SpotifyPlayerContext';
+import { useEffect, useRef } from 'react';
 import { useAuth } from '@/features/auth/hooks/useAuth';
+import { useSpotifyAuthToken } from '@/features/player/hooks/useSpotifyAuthToken';
+import { useSpotifyPlayerCallback } from '@/features/player/hooks/useSpotifyPlayerCallback';
 import SpotifyPlayer from 'react-spotify-web-playback';
 import PlayerErrorBoundary from '@/features/player/components/PlayerErrorBoundary';
 
 export default function SpotifyWebPlayer() {
-  const [token, setToken] = useState<string | null>(null);
-  const [authError, setAuthError] = useState<string | null>(null);
-  const { setDeviceId } = useSpotifyPlayer();
-  const { isChecking: isAuthChecking, isAuthenticated, checkAuth } = useAuth();
-
-  const handleToken = useCallback(async (): Promise<string | null> => {
-    try {
-      const getRes = await fetch('/api/auth/token', { credentials: 'include' });
-      if (getRes.ok) {
-        const data = await getRes.json();
-        setToken(data.token);
-        setAuthError(null); // Clear any previous errors
-        return data.token;
-      }
-
-      if (getRes.status === 401) {
-        console.log('Token expired, attempting refresh...');
-        const refreshRes = await fetch('/api/auth/refresh', { method: 'POST', credentials: 'include' });
-        if (!refreshRes.ok) {
-          console.warn('Refresh failed when called from player getOAuthToken');
-          setToken(null); // Clear token to trigger remount
-          setAuthError('Failed to refresh authentication. Please reload the page.');
-          return null;
-        }
-
-        const retry = await fetch('/api/auth/token', { credentials: 'include' });
-        if (!retry.ok) {
-          setToken(null);
-          setAuthError('Failed to obtain new token after refresh.');
-          return null;
-        }
-        const data = await retry.json();
-        setToken(data.token);
-        setAuthError(null);
-        console.log('Token refreshed successfully');
-        return data.token;
-      }
-
-      setToken(null);
-      setAuthError(`Authentication failed with status ${getRes.status}`);
-      return null;
-    } catch (e) {
-      console.error('Error obtaining token for Spotify SDK:', e);
-      setToken(null);
-      setAuthError('Network error while obtaining token.');
-      return null;
-    }
-  }, []);
+  const { isChecking: isAuthChecking, isAuthenticated } = useAuth();
+  const { token, authError, handleToken, setAuthError } = useSpotifyAuthToken();
+  const handleCallback = useSpotifyPlayerCallback(handleToken);
+  const hasInitialized = useRef(false);
 
   useEffect(() => {
-    let mounted = true;
-    const init = async () => {
-      const ok = await checkAuth();
-      if (!mounted) return;
-      if (!ok) return;
-      await handleToken();
-    };
-    init();
-
-    return () => {
-      mounted = false;
-    };
-  }, [checkAuth, handleToken]);
-
-  const handleCallback = (state: any) => {
-    if (state?.status === 'READY') {
-      try {
-        const deviceId = state?.device_id || state?.deviceId || null;
-        if (deviceId) setDeviceId(deviceId);
-      } catch (e) {
-        console.log('Spotify Player callback error:', e);
-      }
-    }
-
-    // Handle authentication errors from the SDK
-    if (state?.status === 'ERROR' && state?.error?.message?.includes('authentication')) {
-      console.warn('Spotify SDK authentication error detected, attempting token refresh...');
+    if (isAuthenticated && !token && !authError && !hasInitialized.current) {
+      hasInitialized.current = true;
       handleToken();
     }
-  };
+  }, [isAuthenticated, token, authError, handleToken]);
 
   if (isAuthChecking || !isAuthenticated) return null;
-
-  if (authError) {
-    return (
-      <div className="text-center py-4">
-        <p className="text-red-400 text-sm mb-2">{authError}</p>
-        <button
-          onClick={() => {
-            setAuthError(null);
-            handleToken();
-          }}
-          className="text-blue-400 hover:text-blue-300 text-sm underline"
-        >
-          Retry
-        </button>
-      </div>
-    );
-  }
 
   if (!token) {
     return (
       <div className="text-center py-4 text-gray-400 text-sm">
-        Loading player...
+        {authError || 'Loading player...'}
       </div>
     );
   }
 
   return (
-    <PlayerErrorBoundary>
+    <PlayerErrorBoundary onRetry={() => {
+      setAuthError(null);
+      handleToken();
+    }}>
       <SpotifyPlayer
         key={token}
         token={token}

--- a/src/features/player/hooks/useSpotifyAuthToken.tsx
+++ b/src/features/player/hooks/useSpotifyAuthToken.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useAuthApi } from '@/features/auth/hooks/useAuthApi';
+
+export const useSpotifyAuthToken = () => {
+  const [token, setToken] = useState<string | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  const { getToken, refresh } = useAuthApi();
+
+  const handleToken = useCallback(async (): Promise<string | null> => {
+    try {
+      const t = await getToken();
+      setToken(t);
+      setAuthError(null);
+      return t;
+    } catch (err: any) {
+      // If unauthorized, attempt a refresh flow
+      if (err?.message === 'unauthorized') {
+        try {
+          await refresh();
+          const t2 = await getToken();
+          setToken(t2);
+          setAuthError(null);
+          return t2;
+        } catch (rerr: any) {
+          console.warn('Refresh failed when called from player getOAuthToken', rerr);
+          if (rerr?.message === 'gateway') {
+            setAuthError('Authentication gateway error. Try again later.');
+          } else {
+            setAuthError('Failed to refresh authentication. Please reload the page.');
+          }
+          setToken(null);
+          return null;
+        }
+      }
+
+      if (err?.message === 'gateway') {
+        setAuthError('Authentication gateway error. Try again later.');
+        setToken(null);
+        return null;
+      }
+
+      console.error('Error obtaining token for Spotify SDK:', err);
+      setToken(null);
+      setAuthError('Network error while obtaining token.');
+      return null;
+    }
+  }, [getToken, refresh]);
+
+  return { token, authError, handleToken, setAuthError, setToken };
+};

--- a/src/features/player/hooks/useSpotifyPlayerCallback.tsx
+++ b/src/features/player/hooks/useSpotifyPlayerCallback.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useSpotifyPlayer } from '@/features/player/context/SpotifyPlayerContext';
+
+export const useSpotifyPlayerCallback = (handleToken: () => Promise<string | null>) => {
+  const { setDeviceId } = useSpotifyPlayer();
+
+  const handleCallback = useCallback((state: any) => {
+    if (state?.status === 'READY') {
+      try {
+        const deviceId = state?.device_id || state?.deviceId || null;
+        if (deviceId) setDeviceId(deviceId);
+      } catch (e) {
+        console.log('Spotify Player callback error:', e);
+      }
+    }
+
+    // Handle authentication errors from the SDK
+    if (state?.status === 'ERROR' && state?.error?.message?.includes('authentication')) {
+      console.warn('Spotify SDK authentication error detected, attempting token refresh...');
+      handleToken();
+    }
+  }, [setDeviceId, handleToken]);
+
+  return handleCallback;
+};

--- a/src/features/player/index.ts
+++ b/src/features/player/index.ts
@@ -5,5 +5,9 @@ export { SpotifyPlayerProvider, useSpotifyPlayer } from './context/SpotifyPlayer
 export { default as SpotifyWebPlayer } from './components/SpotifyWebPlayer';
 export { default as PlayerErrorBoundary } from './components/PlayerErrorBoundary';
 
+// Hooks
+export { useSpotifyAuthToken } from './hooks/useSpotifyAuthToken';
+export { useSpotifyPlayerCallback } from './hooks/useSpotifyPlayerCallback';
+
 // // Types (add when created)
 // export type { PlayerState, DeviceState } from './types/player';

--- a/src/infrastructure/spotify/api-client.ts
+++ b/src/infrastructure/spotify/api-client.ts
@@ -1,4 +1,0 @@
-// Deprecated wrapper retained temporarily for backwards compatibility.
-// Prefer importing from '@/infrastructure/spotify/client'.
-export { default } from './client';
-export * from './client';


### PR DESCRIPTION
## Description:

Fix token refresh flow to automatically retry when tokens expire or authentication errors occur.

## Objective:

- Successfully use getOAuthToken callback to refresh access token 
- Refactor player component to delegate authentication logic to hooks
- Update error handling to better distinguish between different failure scenarios

## Result:

This pull request introduces several improvements to authentication handling and Spotify Web Player integration, with a focus on error resilience, code modularity, and clearer error feedback. Resolves #19 #20 

**Authentication and Token Management Enhancements:**

* Refactored Spotify token request logic in `postTokenForm` to implement retry with exponential backoff, jitter, and support for `Retry-After` headers, improving resilience against transient errors and rate limits.
* Added a new hook `useAuthApi` to encapsulate token retrieval and refresh logic, providing clear error handling for unauthorized and gateway errors.
* Created `useSpotifyAuthToken` and `useSpotifyPlayerCallback` hooks to modularize Spotify authentication and player callback logic, enabling cleaner separation of concerns and easier reuse.

**Error Handling and User Feedback Improvements:**

* Updated error handling in the refresh API route to provide more accurate feedback for gateway errors.
* Enhanced `PlayerErrorBoundary` to accept an `onRetry` prop, enabling the player UI to provide a retry button and improved recovery from authentication errors.
* Refactored `SpotifyWebPlayer` to use the new hooks and error handling, simplifying the component and improving user feedback for authentication and network errors.

**Codebase Cleanup and Modularization:**

* Removed deprecated exports from `src/infrastructure/spotify/api-client.ts` to clean up legacy code.
* Fixed import path for `LyricsResult` in `useSongLyrics` to point to the correct location.