### PR TITLE
Add Search UI + Page

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
+import { useSpotifyApi, SpotifySearchResponse } from '@/modules/spotify';
+
+const FULL_RESULTS_LIMIT = 50;
+
+function ResultImage({ src, alt }: { src?: string; alt?: string }) {
+  if (!src) {
+    return (
+      <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-white/10 text-xs font-semibold text-white/70">
+        {alt?.slice(0, 1) ?? '?'}
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt ?? 'cover'}
+      width={48}
+      height={48}
+      className="h-12 w-12 rounded-lg object-cover"
+    />
+  );
+}
+
+export default function SearchPage() {
+  const spotify = useSpotifyApi();
+  const searchParams = useSearchParams();
+  const queryParam = searchParams.get('q') ?? '';
+  const query = queryParam.trim();
+
+  const [results, setResults] = useState<SpotifySearchResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (!query) {
+      setResults(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setIsLoading(true);
+    spotify
+      .search(query, { limit: FULL_RESULTS_LIMIT })
+      .then((data) => {
+        if (requestId !== requestIdRef.current) return;
+        setResults(data);
+        setError(null);
+      })
+      .catch((err: any) => {
+        if (requestId !== requestIdRef.current) return;
+        setResults(null);
+        setError(err?.message ?? 'Search failed');
+      })
+      .finally(() => {
+        if (requestId === requestIdRef.current) {
+          setIsLoading(false);
+        }
+      });
+  }, [query, spotify]);
+
+  const tracks = results?.tracks?.items ?? [];
+  const artists = results?.artists?.items ?? [];
+  const albums = results?.albums?.items ?? [];
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 py-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-white">Search</h1>
+        <p className="mt-1 text-sm text-white/60">
+          {query ? `Showing results for “${query}”` : 'Type in the top bar to search Spotify.'}
+        </p>
+      </div>
+
+      {isLoading && <div className="text-sm text-white/60">Searching…</div>}
+      {!isLoading && error && <div className="text-sm text-red-400">{error}</div>}
+
+      {!isLoading && !error && query && tracks.length === 0 && artists.length === 0 && albums.length === 0 && (
+        <div className="text-sm text-white/60">No results found.</div>
+      )}
+
+      {!isLoading && !error && query && (
+        <div className="space-y-8">
+          {tracks.length > 0 && (
+            <section>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-white/60">Songs</h2>
+              <ul className="space-y-2">
+                {tracks.map((track) => (
+                  <li key={track.id}>
+                    <Link href={`/songs/${track.id}`} className="flex items-center gap-4 rounded-xl border border-white/5 bg-white/5 p-3 hover:bg-white/10">
+                      <ResultImage src={track.album?.images?.[0]?.url} alt={track.name} />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm text-white">{track.name}</div>
+                        <div className="truncate text-xs text-white/50">
+                          {track.artists?.map((artist) => artist.name).join(', ')}
+                        </div>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {artists.length > 0 && (
+            <section>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-white/60">Artists</h2>
+              <ul className="space-y-2">
+                {artists.map((artist) => (
+                  <li key={artist.id}>
+                    <Link href={`/artists/${artist.id}`} className="flex items-center gap-4 rounded-xl border border-white/5 bg-white/5 p-3 hover:bg-white/10">
+                      <ResultImage src={artist.images?.[0]?.url} alt={artist.name} />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm text-white">{artist.name}</div>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {albums.length > 0 && (
+            <section>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-white/60">Albums</h2>
+              <ul className="space-y-2">
+                {albums.map((album) => (
+                  <li key={album.id}>
+                    <Link href={`/albums/${album.id}`} className="flex items-center gap-4 rounded-xl border border-white/5 bg-white/5 p-3 hover:bg-white/10">
+                      <ResultImage src={album.images?.[0]?.url} alt={album.name} />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm text-white">{album.name}</div>
+                        {album.artists?.length ? (
+                          <div className="truncate text-xs text-white/50">
+                            {album.artists.map((artist) => artist.name).join(', ')}
+                          </div>
+                        ) : null}
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/songs/[id]/page.tsx
+++ b/src/app/songs/[id]/page.tsx
@@ -35,11 +35,11 @@ export default function Song({ params }: { params: Promise<{ id: string }> }) {
   const hasSynced = !!displayLyrics?.synced;
   const hasWordSynced = !!displayLyrics?.wordSynced;
 
-  useEffect(() => {
-    if (hasWordSynced) {
-      setWordSyncEnabled(true);
-    }
-  }, [hasWordSynced]);
+  // useEffect(() => {
+  //   if (hasWordSynced) {
+  //     setWordSyncEnabled(true);
+  //   }
+  // }, [hasWordSynced]);
 
   useEffect(() => {
     setRhymeColorMappingComplete(!!savedSong?.lyrics?.rhymeColorMappingComplete);

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { Divide as Hamburger } from 'hamburger-react';
 import Navigation from '@/components/Navigation';
 import { SpotifyWebPlayer } from '@/modules/player';
+import SpotifySearchBar from '@/components/SpotifySearchBar';
 
 interface SidebarContextType {
   isOpen: boolean;
@@ -71,12 +72,20 @@ function DashboardUI({ children }: { children: React.ReactNode }) {
       )}
 
       <main className="relative flex flex-1 flex-col w-full h-[100dvh] lg:h-screen">
-        <div className="flex items-center justify-between p-2 shadow-md lg:hidden">
+        <div className="flex items-center justify-between gap-3 p-3 shadow-md lg:hidden">
           <Link href="/">
-            <h1 className="title text-md md:text-lg font-bold">DECODED</h1>
+            <h1 className="title text-sm md:text-md font-bold">DECODED</h1>
           </Link>
+          <div className="flex-1" />
+          <SpotifySearchBar isMobile />
           <div className="position relative z-50">
             <Hamburger toggled={isOpen} toggle={setOpen} rounded />
+          </div>
+        </div>
+
+        <div className="hidden lg:flex items-center justify-center px-6 py-4 border-b border-white/10 bg-black/40">
+          <div className="w-full max-w-2xl">
+            <SpotifySearchBar />
           </div>
         </div>
 

--- a/src/components/SpotifySearchBar.tsx
+++ b/src/components/SpotifySearchBar.tsx
@@ -1,0 +1,481 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { usePathname } from 'next/navigation';
+import { useSpotifyApi, SpotifySearchResponse } from '@/modules/spotify';
+
+const RESULTS_LIMIT = 5;
+const MIN_QUERY_LENGTH = 2;
+
+function getInitials(name?: string) {
+  if (!name) return '?';
+  const parts = name.trim().split(' ').filter(Boolean);
+  const initials = parts.slice(0, 2).map((p) => p[0]).join('');
+  return initials.toUpperCase();
+}
+
+function ResultImage({ src, alt }: { src?: string; alt?: string }) {
+  if (!src) {
+    return (
+      <div className="flex h-9 w-9 items-center justify-center rounded-md bg-white/10 text-xs font-semibold text-white/70">
+        {getInitials(alt)}
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt ?? 'cover'}
+      width={36}
+      height={36}
+      className="h-9 w-9 rounded-md object-cover"
+    />
+  );
+}
+
+export default function SpotifySearchBar({ className = '', isMobile = false }: { className?: string; isMobile?: boolean }) {
+  const spotify = useSpotifyApi();
+  const pathname = usePathname();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const requestIdRef = useRef(0);
+
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SpotifySearchResponse | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedQuery = query.trim();
+  const shouldSearch = trimmedQuery.length >= MIN_QUERY_LENGTH;
+
+  const tracks = results?.tracks?.items ?? [];
+  const artists = results?.artists?.items ?? [];
+  const albums = results?.albums?.items ?? [];
+  const hasResults = tracks.length > 0 || artists.length > 0 || albums.length > 0;
+
+  useEffect(() => {
+    setIsOpen(false);
+    setIsExpanded(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (isMobile && query.length === 0 && !isOpen) {
+      setIsExpanded(false);
+    }
+  }, [query, isOpen, isMobile]);
+
+  useEffect(() => {
+    if (isMobile && isExpanded && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isExpanded, isMobile]);
+
+  useEffect(() => {
+    if (!shouldSearch) {
+      setResults(null);
+      setError(null);
+      setIsOpen(false);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsOpen(true);
+    setIsLoading(true);
+    const requestId = ++requestIdRef.current;
+    const timeoutId = window.setTimeout(async () => {
+      try {
+        const data = await spotify.search(trimmedQuery, { limit: RESULTS_LIMIT });
+        if (requestId !== requestIdRef.current) return;
+        setResults(data);
+        setError(null);
+      } catch (err: any) {
+        if (requestId !== requestIdRef.current) return;
+        setResults(null);
+        setError(err?.message ?? 'Search failed');
+      } finally {
+        if (requestId === requestIdRef.current) {
+          setIsLoading(false);
+        }
+      }
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [shouldSearch, trimmedQuery, spotify]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+        if (isMobile && query.length === 0) {
+          setIsExpanded(false);
+        }
+      }
+    };
+    window.addEventListener('mousedown', handleClickOutside);
+    return () => window.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen, isMobile, query]);
+
+  const viewAllHref = useMemo(() => {
+    if (!shouldSearch) return '/search';
+    return `/search?q=${encodeURIComponent(trimmedQuery)}`;
+  }, [shouldSearch, trimmedQuery]);
+
+  // Mobile: Show icon only initially
+  if (isMobile && !isExpanded) {
+    return (
+      <div ref={containerRef} className={`relative ${className}`}>
+        <button
+          type="button"
+          onClick={() => setIsExpanded(true)}
+          className="flex h-10 w-10 items-center justify-center rounded-full hover:bg-white/10"
+          aria-label="Open search"
+        >
+          <svg
+            className="h-5 w-5 text-white/70"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </button>
+      </div>
+    );
+  }
+
+  // Mobile expanded or desktop: Show full search bar
+  if (isMobile && isExpanded) {
+    return (
+      <div ref={containerRef} className={`relative w-full ${className}`}>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => {
+              if (query.length === 0) {
+                setIsExpanded(false);
+              }
+            }}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-white/40 hover:text-white/70"
+            aria-label="Close search"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+          </button>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onFocus={() => {
+              if (shouldSearch) setIsOpen(true);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                setIsOpen(false);
+                if (query.length === 0) setIsExpanded(false);
+              }
+            }}
+            placeholder={isMobile ? "Search" : "Search songs, artists, albums"}
+            className="w-full rounded-full border border-white/10 bg-white/5 pl-9 pr-10 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+          />
+          {query.length > 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                setIsOpen(false);
+              }}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-white/50 hover:text-white"
+              aria-label="Clear search"
+            >
+              ×
+            </button>
+          )}
+        </div>
+
+        {isOpen && (
+          <div className="absolute left-0 right-0 top-full z-50 mt-2 rounded-xl border border-white/10 bg-black/95 p-4 shadow-lg backdrop-blur">
+            {isLoading && (
+              <div className="text-sm text-white/60">Searching…</div>
+            )}
+
+            {!isLoading && error && (
+              <div className="text-sm text-red-400">{error}</div>
+            )}
+
+            {!isLoading && !error && !hasResults && (
+              <div className="text-sm text-white/60">No results found.</div>
+            )}
+
+            {!isLoading && !error && hasResults && (
+              <div className="space-y-4">
+                {tracks.length > 0 && (
+                  <div>
+                    <div className="mb-2 text-xs uppercase tracking-wide text-white/50">Songs</div>
+                    <ul className="space-y-2">
+                      {tracks.map((track) => (
+                        <li key={track.id}>
+                          <Link
+                            href={`/songs/${track.id}`}
+                            className="flex items-center gap-3 rounded-lg px-2 py-1.5 hover:bg-white/5"
+                            onClick={() => setIsOpen(false)}
+                          >
+                            <ResultImage src={track.album?.images?.[0]?.url} alt={track.name} />
+                            <div className="min-w-0">
+                              <div className="truncate text-sm text-white">{track.name}</div>
+                              <div className="truncate text-xs text-white/50">
+                                {track.artists?.map((artist) => artist.name).join(', ')}
+                              </div>
+                            </div>
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {artists.length > 0 && (
+                  <div>
+                    <div className="mb-2 text-xs uppercase tracking-wide text-white/50">Artists</div>
+                    <ul className="space-y-2">
+                      {artists.map((artist) => (
+                        <li key={artist.id}>
+                          <Link
+                            href={`/artists/${artist.id}`}
+                            className="flex items-center gap-3 rounded-lg px-2 py-1.5 hover:bg-white/5"
+                            onClick={() => setIsOpen(false)}
+                          >
+                            <ResultImage src={artist.images?.[0]?.url} alt={artist.name} />
+                            <div className="min-w-0">
+                              <div className="truncate text-sm text-white">{artist.name}</div>
+                            </div>
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {albums.length > 0 && (
+                  <div>
+                    <div className="mb-2 text-xs uppercase tracking-wide text-white/50">Albums</div>
+                    <ul className="space-y-2">
+                      {albums.map((album) => (
+                        <li key={album.id}>
+                          <Link
+                            href={`/albums/${album.id}`}
+                            className="flex items-center gap-3 rounded-lg px-2 py-1.5 hover:bg-white/5"
+                            onClick={() => setIsOpen(false)}
+                          >
+                            <ResultImage src={album.images?.[0]?.url} alt={album.name} />
+                            <div className="min-w-0">
+                              <div className="truncate text-sm text-white">{album.name}</div>
+                              {album.artists?.length ? (
+                                <div className="truncate text-xs text-white/50">
+                                  {album.artists.map((artist) => artist.name).join(', ')}
+                                </div>
+                              ) : null}
+                            </div>
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {shouldSearch && (
+              <div className="mt-4 border-t border-white/10 pt-3 text-right">
+                <Link
+                  href={viewAllHref}
+                  onClick={() => setIsOpen(false)}
+                  className="text-xs font-semibold uppercase tracking-wide text-blue-400 hover:text-blue-300"
+                >
+                  View all results
+                </Link>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Desktop: Show full search bar
+  return (
+    <div ref={containerRef} className={`relative w-full ${className}`}>
+      <div className="relative">
+        <svg
+          className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-white/40"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onFocus={() => {
+            if (shouldSearch) setIsOpen(true);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              setIsOpen(false);
+            }
+          }}
+          placeholder="Search songs, artists, albums"
+          className="w-full rounded-full border border-white/10 bg-white/5 pl-9 pr-10 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+        />
+        {query.length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              setQuery('');
+              setIsOpen(false);
+            }}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-white/50 hover:text-white"
+            aria-label="Clear search"
+          >
+            ×
+          </button>
+        )}
+      </div>
+      {isOpen && (
+        <div className="absolute left-0 right-0 top-full z-50 mt-2 rounded-xl border border-white/10 bg-black/95 p-4 shadow-lg backdrop-blur">
+          {isLoading && (
+            <div className="text-sm text-white/60">Searching…</div>
+          )}
+
+          {!isLoading && error && (
+            <div className="text-sm text-red-400">{error}</div>
+          )}
+
+          {!isLoading && !error && !hasResults && (
+            <div className="text-sm text-white/60">No results found.</div>
+          )}
+
+          {!isLoading && !error && hasResults && (
+            <div className="space-y-4">
+              {tracks.length > 0 && (
+                <div>
+                  <div className="mb-2 text-xs uppercase tracking-wide text-white/50">Songs</div>
+                  <ul className="space-y-2">
+                    {tracks.map((track) => (
+                      <li key={track.id}>
+                        <Link
+                          href={`/songs/${track.id}`}
+                          className="flex items-center gap-3 rounded-lg px-2 py-1.5 hover:bg-white/5"
+                          onClick={() => setIsOpen(false)}
+                        >
+                          <ResultImage src={track.album?.images?.[0]?.url} alt={track.name} />
+                          <div className="min-w-0">
+                            <div className="truncate text-sm text-white">{track.name}</div>
+                            <div className="truncate text-xs text-white/50">
+                              {track.artists?.map((artist) => artist.name).join(', ')}
+                            </div>
+                          </div>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {artists.length > 0 && (
+                <div>
+                  <div className="mb-2 text-xs uppercase tracking-wide text-white/50">Artists</div>
+                  <ul className="space-y-2">
+                    {artists.map((artist) => (
+                      <li key={artist.id}>
+                        <Link
+                          href={`/artists/${artist.id}`}
+                          className="flex items-center gap-3 rounded-lg px-2 py-1.5 hover:bg-white/5"
+                          onClick={() => setIsOpen(false)}
+                        >
+                          <ResultImage src={artist.images?.[0]?.url} alt={artist.name} />
+                          <div className="min-w-0">
+                            <div className="truncate text-sm text-white">{artist.name}</div>
+                          </div>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {albums.length > 0 && (
+                <div>
+                  <div className="mb-2 text-xs uppercase tracking-wide text-white/50">Albums</div>
+                  <ul className="space-y-2">
+                    {albums.map((album) => (
+                      <li key={album.id}>
+                        <Link
+                          href={`/albums/${album.id}`}
+                          className="flex items-center gap-3 rounded-lg px-2 py-1.5 hover:bg-white/5"
+                          onClick={() => setIsOpen(false)}
+                        >
+                          <ResultImage src={album.images?.[0]?.url} alt={album.name} />
+                          <div className="min-w-0">
+                            <div className="truncate text-sm text-white">{album.name}</div>
+                            {album.artists?.length ? (
+                              <div className="truncate text-xs text-white/50">
+                                {album.artists.map((artist) => artist.name).join(', ')}
+                              </div>
+                            ) : null}
+                          </div>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+
+          {shouldSearch && (
+            <div className="mt-4 border-t border-white/10 pt-3 text-right">
+              <Link
+                href={viewAllHref}
+                onClick={() => setIsOpen(false)}
+                className="text-xs font-semibold uppercase tracking-wide text-blue-400 hover:text-blue-300"
+              >
+                View all results
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/spotify/endpoints.ts
+++ b/src/lib/spotify/endpoints.ts
@@ -4,6 +4,12 @@ export const spotifyEndpoints = {
   album: (id: string) => `/albums/${id}`,
   artist: (id: string) => `/artists/${id}`,
   artistAlbums: (id: string) => `/artists/${id}/albums`,
+  search: (
+    query: string,
+    types: Array<'track' | 'artist' | 'album'> = ['track', 'artist', 'album'],
+    limit = 5,
+    offset = 0
+  ) => `/search?q=${encodeURIComponent(query)}&type=${types.join(',')}&limit=${limit}&offset=${offset}`,
   topArtists: (limit = 20) => `/me/top/artists?limit=${limit}`,
   playback: () => '/me/player',
   transferPlayback: () => '/me/player',

--- a/src/modules/spotify/index.ts
+++ b/src/modules/spotify/index.ts
@@ -26,5 +26,7 @@ export type {
   SpotifyAlbum,
   SpotifyRequestOptions,
   PlaybackState,
-  SavedTracksResponse
+  SavedTracksResponse,
+  SpotifySearchResult,
+  SpotifySearchResponse
 } from './types/spotify';

--- a/src/modules/spotify/services/spotifyService.ts
+++ b/src/modules/spotify/services/spotifyService.ts
@@ -5,7 +5,8 @@ import {
   SpotifyArtist, 
   SpotifyAlbum, 
   PlaybackState, 
-  SavedTracksResponse  
+  SavedTracksResponse,
+  SpotifySearchResponse
 } from '@/modules/spotify';
 
 /**
@@ -49,6 +50,20 @@ export function createSpotifyService(transport: SpotifyTransport) {
 
     async getArtistAlbums(artistId: string): Promise<{ items: SpotifyAlbum[] }> {
       return transport.request<{ items: SpotifyAlbum[] }>('GET', spotifyEndpoints.artistAlbums(artistId));
+    },
+
+    async search(
+      query: string,
+      options?: { limit?: number; offset?: number; types?: Array<'track' | 'artist' | 'album'> }
+    ): Promise<SpotifySearchResponse> {
+      const limit = options?.limit ?? 5;
+      const offset = options?.offset ?? 0;
+      const types = options?.types ?? ['track', 'artist', 'album'];
+
+      return transport.request<SpotifySearchResponse>(
+        'GET',
+        spotifyEndpoints.search(query, types, limit, offset)
+      );
     },
 
     async play(deviceId?: string, uris?: string[], position_ms?: number): Promise<void> {

--- a/src/modules/spotify/types/spotify.ts
+++ b/src/modules/spotify/types/spotify.ts
@@ -9,6 +9,8 @@ export interface SpotifyAlbum {
   id: string;
   name: string;
   images: { url: string; width?: number; height?: number }[];
+  artists?: { id: string; name: string }[];
+  release_date?: string;
   tracks?: {
     items: SpotifyTrack[];
   };
@@ -44,4 +46,17 @@ export interface SavedTracksResponse {
   limit: number;
   offset: number;
   total: number;
+}
+
+export interface SpotifySearchResult<T> {
+  items: T[];
+  limit: number;
+  offset: number;
+  total: number;
+}
+
+export interface SpotifySearchResponse {
+  tracks?: SpotifySearchResult<SpotifyTrack>;
+  artists?: SpotifySearchResult<SpotifyArtist>;
+  albums?: SpotifySearchResult<SpotifyAlbum>;
 }


### PR DESCRIPTION
## Description ##

Add Search Funtionality

## Objective ##

- [x] Add Search UI + Responsive Styles
- [x] Dropdown results via groups of artist, album or title that match user input
- [x] add view all CTA that links to search page
- [x] search page displays all results

## Result ##


This pull request adds a comprehensive Spotify search feature to the application, including backend service integration and a new search page UI. It introduces a new API method for searching tracks, artists, and albums, updates related data types, and integrates the search bar into the dashboard layout for both mobile and desktop.


**Spotify Search Feature Implementation**

**User Interface Enhancements**